### PR TITLE
add missing env support to a step

### DIFF
--- a/libs/github/src/Actions.Workflow/Step.cs
+++ b/libs/github/src/Actions.Workflow/Step.cs
@@ -8,6 +8,7 @@ public class Step
     private readonly string?   _id;
     private          string    _name        = string.Empty;
     private          string    _conditional = string.Empty;
+    private          StepEnv?  _env;
     private          string    _uses        = string.Empty;
     private          StepWith? _with;
     private          string    _run            = string.Empty;
@@ -57,6 +58,18 @@ public class Step
     {
         _uses = uses;
         return this;
+    }
+
+    /// <summary>
+    /// A map of environment variables that are available to the step.
+    /// See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#env
+    /// </summary>
+    /// <param name="map"></param>
+    /// <returns>The step.</returns>
+    public Step Env(params (string Key, string Value)[] map)
+    {
+        _env = new(this, map.ToDictionary());
+        return _env.Step;
     }
 
     /// <summary>
@@ -149,6 +162,9 @@ public class Step
         {
             node.Add("run", _run);
         }
+        
+        // Env
+        _env?.Build(node);
 
         if (!string.IsNullOrWhiteSpace(_shell))
         {

--- a/libs/github/src/Actions.Workflow/StepEnv.cs
+++ b/libs/github/src/Actions.Workflow/StepEnv.cs
@@ -1,0 +1,9 @@
+namespace Logicality.GitHub.Actions.Workflow;
+
+public class StepEnv: StepKeyValueMap<StepEnv>
+{
+    public StepEnv(Step step, IDictionary<string, string> map)
+        : base(step, "env", map)
+    {
+    }
+}

--- a/libs/github/src/Actions.Workflow/StepKeyValueMap.cs
+++ b/libs/github/src/Actions.Workflow/StepKeyValueMap.cs
@@ -1,0 +1,31 @@
+namespace Logicality.GitHub.Actions.Workflow;
+
+public abstract class StepKeyValueMap<T> : KeyValueMap<T> where T : StepKeyValueMap<T>
+{
+    protected StepKeyValueMap(Step step, string nodeName)
+        : base(nodeName)
+    {
+        Step = step;
+    }
+
+    protected StepKeyValueMap(Step step, string nodeName, IDictionary<string, string> map)
+        : base(nodeName, map)
+    {
+        Step = step;
+    }
+
+    /// <summary>
+    /// The associated Job
+    /// </summary>
+    public Step Step { get; }
+
+    /// <summary>
+    /// The associated Job
+    /// </summary>
+    public Job Job => Step.Job;
+
+    /// <summary>
+    /// The associated Workflow
+    /// </summary>
+    public Workflow Workflow => Job.Workflow;
+}

--- a/libs/github/src/Actions.Workflow/StepKeyValueMap.cs
+++ b/libs/github/src/Actions.Workflow/StepKeyValueMap.cs
@@ -15,7 +15,7 @@ public abstract class StepKeyValueMap<T> : KeyValueMap<T> where T : StepKeyValue
     }
 
     /// <summary>
-    /// The associated Job
+    /// The associated Step
     /// </summary>
     public Step Step { get; }
 

--- a/libs/github/test/Actions.Workflow.Tests/JobStepTests.cs
+++ b/libs/github/test/Actions.Workflow.Tests/JobStepTests.cs
@@ -99,6 +99,29 @@ jobs:
     }
 
     [Fact]
+    public void Step_Env()
+    {
+        var actual = new Workflow("workflow")
+            .Job("build")
+            .Step("step")
+            .Env(("GITHUB_TOKEN", "${{secrets.GITHUB_TOKEN}}"))
+            .Workflow
+            .GetYaml();
+
+        var expected = Workflow.Header + @"
+
+name: workflow
+jobs:
+  build:
+    steps:
+    - id: step
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}";
+
+        actual.ShouldBe(expected);
+    }
+
+    [Fact]
     public void Step_Shell()
     {
         var actual = new Workflow("workflow")


### PR DESCRIPTION
This PR adds support to pass in environment variables via `Env` and emits `env` as part of the `Step` yaml generation.