### PR TITLE
add working-directory support to step

### DIFF
--- a/libs/github/src/Actions.Workflow/Step.cs
+++ b/libs/github/src/Actions.Workflow/Step.cs
@@ -6,14 +6,15 @@ namespace Logicality.GitHub.Actions.Workflow;
 public class Step
 {
     private readonly string?   _id;
-    private          string    _name        = string.Empty;
-    private          string    _conditional = string.Empty;
+    private          string    _name             = string.Empty;
+    private          string    _conditional      = string.Empty;
     private          StepEnv?  _env;
-    private          string    _uses        = string.Empty;
+    private          string    _uses             = string.Empty;
     private          StepWith? _with;
-    private          string    _run            = string.Empty;
-    private          string    _shell          = string.Empty;
-    private          int       _timeoutMinutes = 0;
+    private          string    _run              = string.Empty;
+    private          string    _workingDirectory = string.Empty;
+    private          string    _shell            = string.Empty;
+    private          int       _timeoutMinutes   = 0;
     private          bool      _continueOnError;
 
     internal Step(string? id, Job job)
@@ -97,6 +98,18 @@ public class Step
     }
 
     /// <summary>
+    /// Specifies the working directory where to run the command. Only emitted when used in conjunction with `Run`.
+    /// See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    /// </summary>
+    /// <param name="workingDirectory"></param>
+    /// <returns></returns>
+    public Step WorkingDirectory(string workingDirectory)
+    {
+        _workingDirectory = workingDirectory;
+        return this;
+    }
+
+    /// <summary>
     /// Iverride the default shell settings.
     /// See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
     /// </summary>
@@ -161,6 +174,11 @@ public class Step
         if (!string.IsNullOrWhiteSpace(_run))
         {
             node.Add("run", _run);
+            
+            if (!string.IsNullOrWhiteSpace(_workingDirectory))
+            {
+                node.Add("working-directory", _workingDirectory);
+            }
         }
         
         // Env

--- a/libs/github/test/Actions.Workflow.Tests/JobStepTests.cs
+++ b/libs/github/test/Actions.Workflow.Tests/JobStepTests.cs
@@ -74,6 +74,53 @@ jobs:
 
         actual.ShouldBe(expected);
     }
+    
+    [Fact]
+    public void Step_WorkingDirectory_With_Run()
+    {
+        var actual = new Workflow("workflow")
+            .Job("build")
+            .Step("step")
+            .Run("./build.ps1 push")
+            .WorkingDirectory("./builder")
+            .Workflow
+            .GetYaml();
+
+        var expected = Workflow.Header + @"
+
+name: workflow
+jobs:
+  build:
+    steps:
+    - id: step
+      run: ./build.ps1 push
+      working-directory: ./builder
+";
+
+        actual.ShouldBe(expected);
+    }
+    
+    [Fact]
+    public void Step_WorkingDirectory_Without_Run()
+    {
+        var actual = new Workflow("workflow")
+            .Job("build")
+            .Step("step")
+            .WorkingDirectory("./builder")
+            .Workflow
+            .GetYaml();
+
+        var expected = Workflow.Header + @"
+
+name: workflow
+jobs:
+  build:
+    steps:
+    - id: step
+";
+
+        actual.ShouldBe(expected);
+    }
 
     [Fact]
     public void Step_Uses()
@@ -116,7 +163,8 @@ jobs:
     steps:
     - id: step
       env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}";
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+";
 
         actual.ShouldBe(expected);
     }


### PR DESCRIPTION
This PR adds support for `working-directory` to a `Step` if and only if used in conjunction with `Run()`. Fixes line-endings of tests to be inline with the rest of the tests.